### PR TITLE
Introduces PUT /hotels/:address

### DIFF
--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -198,8 +198,35 @@ paths:
           $ref: '#/components/responses/UnprocessableEntityError'
         '502':
           $ref: '#/components/responses/BadGatewayError'
+    put:
+      summary: Update hotel even if original off-chain data is inaccessible.
+      Replaces all of the data.
+      security:
+        - AccessKey: []
+          WalletPassword: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HotelPatch'
+      responses:
+        '204':
+          description: Hotel was successfully updated.
+        '400':
+          $ref: '#/components/responses/BadRequestError'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '404':
+          $ref: '#/components/responses/NotFoundError'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntityError'
+        '502':
+          $ref: '#/components/responses/BadGatewayError'
     patch:
-      summary: Update hotel.
+      summary: Update hotel only when original off-chain data can be accessed.
       security:
         - AccessKey: []
           WalletPassword: []

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -199,8 +199,9 @@ paths:
         '502':
           $ref: '#/components/responses/BadGatewayError'
     put:
-      summary: Update hotel even if original off-chain data is inaccessible.
-      Replaces all of the data.
+      summary: >-
+        Update hotel even if original off-chain data is inaccessible.
+        Replaces all of the data.
       security:
         - AccessKey: []
           WalletPassword: []

--- a/src/app.js
+++ b/src/app.js
@@ -9,8 +9,8 @@ const YAML = require('yamljs');
 const config = require('./config');
 const { version } = require('../package.json');
 const { HttpError, HttpInternalError, Http404Error, HttpBadRequestError } = require('./errors');
-const { attachAccount, handleOnChainErrors } = require('./middleware');
-const { createHotel, updateHotel, deleteHotel, getHotel,
+const { attachAccount, handleOnChainErrors, handleDataFetchingErrors } = require('./middleware');
+const { createHotel, updateHotel, forceUpdateHotel, deleteHotel, getHotel,
   transferHotel } = require('./controllers/hotels');
 const { createAccount, updateAccount, deleteAccount } = require('./controllers/accounts');
 
@@ -66,7 +66,8 @@ app.delete('/accounts/:id', attachAccount, deleteAccount);
 app.post('/hotels', attachAccount, createHotel, handleOnChainErrors);
 app.get('/hotels/:address', getHotel, handleOnChainErrors);
 app.delete('/hotels/:address', attachAccount, deleteHotel, handleOnChainErrors);
-app.patch('/hotels/:address', attachAccount, updateHotel, handleOnChainErrors);
+app.patch('/hotels/:address', attachAccount, updateHotel, handleOnChainErrors, handleDataFetchingErrors);
+app.put('/hotels/:address', attachAccount, forceUpdateHotel, handleOnChainErrors, handleDataFetchingErrors);
 app.post('/hotels/:address/transfer', attachAccount, transferHotel, handleOnChainErrors);
 
 // 404 handler

--- a/src/controllers/hotels.js
+++ b/src/controllers/hotels.js
@@ -117,79 +117,99 @@ module.exports.createHotel = async (req, res, next) => {
   }
 };
 
+const updateHotelFactory = (ignoreGetOriginalDataError) => {
+  return async (req, res, next) => {
+    try {
+      const account = req.account,
+        wt = WT.get();
+      if (!wt.isValidAddress(req.params.address)) {
+        throw new Http404Error('notFound', 'Hotel not found.');
+      }
+      // 1. Validate request.
+      _validateRequest(req.body, false);
+      if (Object.keys(req.body).length === 0) {
+        throw new HttpBadRequestError('badRequest', 'No data provided');
+      }
+      // 2. Add `updatedAt` timestamps.
+      _addTimestamps(req.body);
+
+      // 3. Upload the changed data parts.
+      let dataIndex = {},
+        uploading = [],
+        notificationSubjects = [],
+        origDataIndex;
+      try {
+        origDataIndex = await wt.getDataIndex(req.params.address);
+      } catch (e) {
+        if (!ignoreGetOriginalDataError) {
+          throw e;
+        }
+        origDataIndex = { contents: {} };
+      }
+      for (let field of WT.DATA_INDEX_FIELDS) {
+        let data = req.body[field.name];
+        if (!data) {
+          continue;
+        }
+        if (field.pointer) {
+          let uploader = account.uploaders.getUploader(field.name);
+          uploading.push((async () => {
+            const docKey = `${field.name}Uri`;
+            let preferredUrl = origDataIndex.contents[docKey];
+            dataIndex[docKey] = await uploader.upload(data, field.name, preferredUrl);
+            notificationSubjects.push(field.name);
+          })());
+        } else {
+          dataIndex[`${field.name}Uri`] = data;
+        }
+      }
+      await Promise.all(uploading);
+
+      // 4. Find out if the data index and wt index need to be reuploaded.
+      const newContents = Object.assign({}, origDataIndex.contents, dataIndex);
+      if (!_.isEqual(origDataIndex.contents, newContents)) {
+        let uploader = account.uploaders.getUploader('root');
+        const dataIndexUri = await uploader.upload(newContents, 'dataIndex', origDataIndex.ref);
+        notificationSubjects.push('dataIndex');
+        if (dataIndexUri !== origDataIndex.ref) {
+          await wt.upload(account.withWallet, dataIndexUri, req.params.address);
+          notificationSubjects.push('onChain');
+        }
+      }
+
+      // 5. Publish update notifications, if applicable.
+      const notificationsUris = new Set([
+        dataIndex.notificationsUri,
+        origDataIndex.contents.notificationsUri,
+      ].filter(Boolean));
+      for (let notificationsUri of notificationsUris) {
+        try {
+          await publishHotelUpdated(notificationsUri, wt.wtIndexAddress,
+            req.params.address, notificationSubjects);
+        } catch (err) {
+          logger.info(`Could not publish notification to ${notificationsUri}: ${err}`);
+        }
+      }
+      res.sendStatus(204);
+    } catch (err) {
+      if (err instanceof ValidationError) {
+        return next(new HttpValidationError('validationFailed', err.message));
+      }
+      next(err);
+    }
+  };
+};
+
 /**
  * Update hotel information.
  */
-module.exports.updateHotel = async (req, res, next) => {
-  try {
-    const account = req.account,
-      wt = WT.get();
-    if (!wt.isValidAddress(req.params.address)) {
-      throw new Http404Error('notFound', 'Hotel not found.');
-    }
-    // 1. Validate request.
-    _validateRequest(req.body, false);
-    if (Object.keys(req.body).length === 0) {
-      throw new HttpBadRequestError('badRequest', 'No data provided');
-    }
-    // 2. Add `updatedAt` timestamps.
-    _addTimestamps(req.body);
-    // 3. Upload the changed data parts.
-    let dataIndex = {},
-      uploading = [];
-    const notificationSubjects = [],
-      origDataIndex = await wt.getDataIndex(req.params.address);
-    for (let field of WT.DATA_INDEX_FIELDS) {
-      let data = req.body[field.name];
-      if (!data) {
-        continue;
-      }
-      if (field.pointer) {
-        let uploader = account.uploaders.getUploader(field.name);
-        uploading.push((async () => {
-          const docKey = `${field.name}Uri`;
-          let preferredUrl = origDataIndex.contents[docKey];
-          dataIndex[docKey] = await uploader.upload(data, field.name, preferredUrl);
-          notificationSubjects.push(field.name);
-        })());
-      } else {
-        dataIndex[`${field.name}Uri`] = data;
-      }
-    }
-    await Promise.all(uploading);
+module.exports.updateHotel = updateHotelFactory(false);
 
-    // 4. Find out if the data index and wt index need to be reuploaded.
-    const newContents = Object.assign({}, origDataIndex.contents, dataIndex);
-    if (!_.isEqual(origDataIndex.contents, newContents)) {
-      let uploader = account.uploaders.getUploader('root');
-      const dataIndexUri = await uploader.upload(newContents, 'dataIndex', origDataIndex.ref);
-      notificationSubjects.push('dataIndex');
-      if (dataIndexUri !== origDataIndex.ref) {
-        await wt.upload(account.withWallet, dataIndexUri, req.params.address);
-        notificationSubjects.push('onChain');
-      }
-    }
-    // 5. Publish update notifications, if applicable.
-    const notificationsUris = new Set([
-      dataIndex.notificationsUri,
-      origDataIndex.contents.notificationsUri,
-    ].filter(Boolean));
-    for (let notificationsUri of notificationsUris) {
-      try {
-        await publishHotelUpdated(notificationsUri, wt.wtIndexAddress,
-          req.params.address, notificationSubjects);
-      } catch (err) {
-        logger.info(`Could not publish notification to ${notificationsUri}: ${err}`);
-      }
-    }
-    res.sendStatus(204);
-  } catch (err) {
-    if (err instanceof ValidationError) {
-      return next(new HttpValidationError('validationFailed', err.message));
-    }
-    next(err);
-  }
-};
+/**
+ * Update hotel information even if the original off-chain
+ * data is inaccessible.
+ */
+module.exports.forceUpdateHotel = updateHotelFactory(true);
 
 /**
  * Delete the hotel from WT index.

--- a/src/controllers/hotels.js
+++ b/src/controllers/hotels.js
@@ -117,7 +117,7 @@ module.exports.createHotel = async (req, res, next) => {
   }
 };
 
-const updateHotelFactory = (ignoreGetOriginalDataError) => {
+const updateHotelFactory = (ignoreOriginalData) => {
   return async (req, res, next) => {
     try {
       const account = req.account,
@@ -137,14 +137,9 @@ const updateHotelFactory = (ignoreGetOriginalDataError) => {
       let dataIndex = {},
         uploading = [],
         notificationSubjects = [],
-        origDataIndex;
-      try {
-        origDataIndex = await wt.getDataIndex(req.params.address);
-      } catch (e) {
-        if (!ignoreGetOriginalDataError) {
-          throw e;
-        }
         origDataIndex = { contents: {} };
+      if (!ignoreOriginalData) {
+        origDataIndex = await wt.getDataIndex(req.params.address);
       }
       for (let field of WT.DATA_INDEX_FIELDS) {
         let data = req.body[field.name];

--- a/src/controllers/hotels.js
+++ b/src/controllers/hotels.js
@@ -126,10 +126,10 @@ const updateHotelFactory = (ignoreOriginalData) => {
         throw new Http404Error('notFound', 'Hotel not found.');
       }
       // 1. Validate request.
-      _validateRequest(req.body, false);
       if (Object.keys(req.body).length === 0) {
         throw new HttpBadRequestError('badRequest', 'No data provided');
       }
+      _validateRequest(req.body, ignoreOriginalData);
       // 2. Add `updatedAt` timestamps.
       _addTimestamps(req.body);
 

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -70,3 +70,18 @@ module.exports.handleOnChainErrors = (err, req, res, next) => {
   }
   next(err);
 };
+
+/**
+ * Replace well-defined off-chain errors with the corresponding
+ * HTTP errors.
+ */
+module.exports.handleDataFetchingErrors = (err, req, res, next) => {
+  if (!err) {
+    return next();
+  }
+  if (err instanceof WTLibs.errors.StoragePointerError) {
+    return next(new HttpBadGatewayError('hotelNotAccessible', err.message, 'Cannot access off-chain data'));
+  }
+  
+  next(err);
+};

--- a/test/controllers/hotels.spec.js
+++ b/test/controllers/hotels.spec.js
@@ -369,6 +369,22 @@ describe('controllers - hotels', function () {
         });
     });
 
+    it('should return 502 if original data is inaccessible', (done) => {
+      offChainUploader.upload.resetHistory();
+      wtMock.upload.resetHistory();
+      const origGetDataIndex = wtMock.getDataIndex;
+      wtMock.getDataIndex = sinon.stub().callsFake(() => Promise.reject(new WTLibs.errors.StoragePointerError('for example timeout')));
+      request(server)
+        .patch('/hotels/0xchanged')
+        .set(ACCESS_KEY_HEADER, accessKey)
+        .set(WALLET_PASSWORD_HEADER, 'windingtree')
+        .send({ description })
+        .expect(502, () => {
+          wtMock.getDataIndex = origGetDataIndex;
+          done();
+        });
+    });
+
     it('should publish the update notification', (done) => {
       requestLibMock.resetHistory();
       request(server)
@@ -454,6 +470,207 @@ describe('controllers - hotels', function () {
     it('should return 404 when hotel address is unknown or invalid', (done) => {
       request(server)
         .patch('/hotels/0xinvalidaddr')
+        .set(ACCESS_KEY_HEADER, accessKey)
+        .set(WALLET_PASSWORD_HEADER, 'windingtree')
+        .send({ description })
+        .expect(404)
+        .end(done);
+    });
+  });
+
+  describe('PUT /hotels/:address', () => {
+    it('should reupload the given subtrees', (done) => {
+      const desc = getDescription(),
+        ratePlans = getRatePlans();
+      offChainUploader.upload.resetHistory();
+      wtMock.upload.resetHistory();
+
+      request(server)
+        .put('/hotels/dummy')
+        .set(ACCESS_KEY_HEADER, accessKey)
+        .set(WALLET_PASSWORD_HEADER, 'windingtree')
+        .send({
+          description: desc,
+          ratePlans: ratePlans,
+        })
+        .expect(204)
+        .end((err, res) => {
+          if (err) return done(err);
+          try {
+            assert.equal(wtMock.upload.callCount, 0);
+            assert.equal(offChainUploader.upload.callCount, 2);
+            assert.ok(offChainUploader.upload.calledWithExactly(desc, 'description', 'dummy://description.json'));
+            assert.ok(offChainUploader.upload.calledWithExactly(ratePlans, 'ratePlans', 'dummy://ratePlans.json'));
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+    });
+
+    it('should update data index and on-chain record if necessary', (done) => {
+      offChainUploader.upload.resetHistory();
+      wtMock.upload.resetHistory();
+
+      request(server)
+        .put('/hotels/0xchanged')
+        .set(ACCESS_KEY_HEADER, accessKey)
+        .set(WALLET_PASSWORD_HEADER, 'windingtree')
+        .send({ description })
+        .expect(204)
+        .end((err, res) => {
+          if (err) return done(err);
+          try {
+            assert.equal(wtMock.upload.callCount, 1);
+            assert.equal(wtMock.upload.getCall(0).args[1], 'dummy://dataIndex.json');
+            assert.equal(wtMock.upload.getCall(0).args[2], '0xchanged');
+            assert.equal(offChainUploader.upload.callCount, 2);
+            assert.equal(offChainUploader.upload.args[0][1], 'description');
+            assert.equal(offChainUploader.upload.args[1][1], 'dataIndex');
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+    });
+
+    it('should not update data index and on-chain record if not necessary', (done) => {
+      offChainUploader.upload.resetHistory();
+      wtMock.upload.resetHistory();
+
+      request(server)
+        .put('/hotels/0xnotchanged')
+        .set(ACCESS_KEY_HEADER, accessKey)
+        .set(WALLET_PASSWORD_HEADER, 'windingtree')
+        .send({ description })
+        .expect(204)
+        .end((err, res) => {
+          if (err) return done(err);
+          try {
+            assert.equal(wtMock.upload.callCount, 0);
+            assert.equal(offChainUploader.upload.callCount, 1);
+            assert.equal(offChainUploader.upload.args[0][1], 'description');
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+    });
+
+    it('should update data index and all other data if original data is inaccessible', (done) => {
+      offChainUploader.upload.resetHistory();
+      wtMock.upload.resetHistory();
+      const origGetDataIndex = wtMock.getDataIndex;
+      wtMock.getDataIndex = sinon.stub().callsFake(() => Promise.reject(new WTLibs.errors.StoragePointerError('for example timeout')));
+
+      request(server)
+        .put('/hotels/0xchanged')
+        .set(ACCESS_KEY_HEADER, accessKey)
+        .set(WALLET_PASSWORD_HEADER, 'windingtree')
+        .send({ description })
+        .expect(204)
+        .end((err, res) => {
+          if (err) return done(err);
+          try {
+            assert.equal(wtMock.upload.callCount, 1);
+            assert.equal(wtMock.upload.getCall(0).args[1], 'dummy://dataIndex.json');
+            assert.equal(wtMock.upload.getCall(0).args[2], '0xchanged');
+            assert.equal(offChainUploader.upload.callCount, 2);
+            assert.equal(offChainUploader.upload.args[0][1], 'description');
+            assert.equal(offChainUploader.upload.args[1][1], 'dataIndex');
+            wtMock.getDataIndex = origGetDataIndex;
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+    });
+
+    it('should publish the update notification', (done) => {
+      requestLibMock.resetHistory();
+      request(server)
+        .put('/hotels/0xchanged')
+        .set(ACCESS_KEY_HEADER, accessKey)
+        .set(WALLET_PASSWORD_HEADER, 'windingtree')
+        .send({ description })
+        .end((err, res) => {
+          if (err) return done(err);
+          try {
+            assert.equal(requestLibMock.callCount, 1);
+            assert.deepEqual(requestLibMock.args[0], ['http://notifications.example/notifications', {
+              method: 'POST',
+              json: true,
+              responseType: 'text',
+              body: {
+                wtIndex: '0xwtIndex',
+                resourceType: 'hotel',
+                resourceAddress: '0xchanged',
+                scope: {
+                  action: 'update',
+                  subjects: ['description', 'dataIndex', 'onChain'],
+                },
+              },
+            }]);
+            done();
+          } catch (e) {
+            done(e);
+          }
+        });
+    });
+
+    it('should return 401 when authorization headers are missing', (done) => {
+      const desc = getDescription(),
+        ratePlans = getRatePlans();
+      request(server)
+        .put('/hotels/dummy')
+        .send({ description: desc, ratePlans: ratePlans })
+        .expect(401)
+        .end(done);
+    });
+
+    it('should return 422 when data format is wrong', (done) => {
+      const desc = getDescription(),
+        ratePlans = getRatePlans();
+      delete desc.name;
+      request(server)
+        .put('/hotels/dummy')
+        .set(ACCESS_KEY_HEADER, accessKey)
+        .set(WALLET_PASSWORD_HEADER, 'windingtree')
+        .send({
+          description: desc,
+          ratePlans: ratePlans,
+        })
+        .expect(422)
+        .end(done);
+    });
+
+    it('should return 422 when unexpected top-level properties are present', (done) => {
+      request(server)
+        .put('/hotels/dummy')
+        .set(ACCESS_KEY_HEADER, accessKey)
+        .set(WALLET_PASSWORD_HEADER, 'windingtree')
+        .send({
+          description: getDescription(),
+          ratePlans: getRatePlans(),
+          religion: 'pagan',
+        })
+        .expect(422)
+        .end(done);
+    });
+
+    it('should return 400 when no data is sent', (done) => {
+      request(server)
+        .put('/hotels/dummy')
+        .set(ACCESS_KEY_HEADER, accessKey)
+        .set(WALLET_PASSWORD_HEADER, 'windingtree')
+        .send({})
+        .expect(400)
+        .end(done);
+    });
+
+    it('should return 404 when hotel address is unknown or invalid', (done) => {
+      request(server)
+        .put('/hotels/0xinvalidaddr')
         .set(ACCESS_KEY_HEADER, accessKey)
         .set(WALLET_PASSWORD_HEADER, 'windingtree')
         .send({ description })

--- a/test/controllers/hotels.spec.js
+++ b/test/controllers/hotels.spec.js
@@ -647,6 +647,18 @@ describe('controllers - hotels', function () {
         .end(done);
     });
 
+    it('should return 422 when required properties are missing', (done) => {
+      request(server)
+        .put('/hotels/dummy')
+        .set(ACCESS_KEY_HEADER, accessKey)
+        .set(WALLET_PASSWORD_HEADER, 'windingtree')
+        .send({
+          ratePlans: getRatePlans(),
+        })
+        .expect(422)
+        .end(done);
+    });
+
     it('should return 400 when no data is sent', (done) => {
       request(server)
         .put('/hotels/dummy')


### PR DESCRIPTION
It differs from PATCH in that it does not crash
when the original off-chain data cannot be accessed.
This allows for hotel update even if the original
data for example disappears from a distributed storage.

Fixes #32