### PR TITLE
feat(docker): Drops the need for build args

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,16 +22,10 @@ jobs:
     - pip install --user awscli
     - export PATH=$PATH:$HOME/.local/bin
     - eval $(aws ecr get-login --no-include-email --region eu-west-1)
-    - echo "Building for playground"
-    - docker build --build-arg WT_CONFIG=playground -t wt-write-api:$TRAVIS_BRANCH-playground
-      .
-    - docker tag wt-write-api:$TRAVIS_BRANCH-playground 029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-write-api:$TRAVIS_BRANCH-playground
-    - docker push 029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-write-api:$TRAVIS_BRANCH-playground
-    - echo "Building for demo"
-    - docker build --build-arg WT_CONFIG=demo -t wt-write-api:$TRAVIS_BRANCH-demo
-      .
-    - docker tag wt-write-api:$TRAVIS_BRANCH-demo 029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-write-api:$TRAVIS_BRANCH-demo
-    - docker push 029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-write-api:$TRAVIS_BRANCH-demo
+    - echo "Building docker image"
+    - docker build -t wt-write-api:$TRAVIS_BRANCH .
+    - docker tag wt-write-api:$TRAVIS_BRANCH 029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-write-api:$TRAVIS_BRANCH
+    - docker push 029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-write-api:$TRAVIS_BRANCH
   - stage: Start service from docker with latest merged tag
     install: true
     sudo: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,6 @@ RUN npm ci
 
 COPY . .
 
-ARG WT_CONFIG
-
-RUN npm run createdb
-
-CMD ["npm", "start"]
+CMD ["npm", "run", "docker-start"]
 
 EXPOSE 8000

--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ You can fiddle with the configuration in `src/config/`.
 ### Running node against Ropsten testnet contract
 
 - To make trying out the node even simpler, we prepared a Docker image pre-configured
-to talk with one of our testing contracts deployed on Ropsten.
+to talk with one of our testing contracts deployed on Ropsten. This is currently pinned
+to SQLite database.
 - You can use it in your local environment by running the following commands:
 ```sh
-$ docker build --build-arg WT_CONFIG=playground -t windingtree/wt-write-api .
+$ docker build -t windingtree/wt-write-api .
 $ docker run -p 8080:8000 -e WT_CONFIG=playground windingtree/wt-write-api
 ```
 - After that you can access the wt-write-api on local port `8080`

--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ You can fiddle with the configuration in `src/config/`.
 
 - To make trying out the node even simpler, we prepared a Docker image pre-configured
 to talk with one of our testing contracts deployed on Ropsten. This is currently pinned
-to SQLite database.
+to SQLite database. You can skip database setup during the container startup with `SKIP_DB_SETUP`
+environment variable.
 - You can use it in your local environment by running the following commands:
 ```sh
 $ docker build -t windingtree/wt-write-api .

--- a/management/createdb.js
+++ b/management/createdb.js
@@ -1,7 +1,7 @@
 const { setupDB } = require('../src/db');
 
 setupDB().then(() => {
-  console.log('Created');
+  console.log('DB is all set');
   process.exit(0);
 }, (err) => {
   console.log(`Error: ${err}`);

--- a/management/createdb.js
+++ b/management/createdb.js
@@ -1,3 +1,8 @@
+if (process.env.SKIP_DB_SETUP) {
+  console.log('Skipping DB setup');
+  process.exit(0);
+}
+
 const { setupDB } = require('../src/db');
 
 setupDB().then(() => {

--- a/management/deploy-aws.sh
+++ b/management/deploy-aws.sh
@@ -37,7 +37,7 @@ TASK_DEF="[{\"portMappings\": [{\"hostPort\": 0,\"protocol\": \"tcp\",\"containe
         \"value\": \"$WT_CONFIG\"
       }
     ],
-    \"image\": \"029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-write-api:$LATEST_TAG-$ENVIRONMENT\",
+    \"image\": \"029479441096.dkr.ecr.eu-west-1.amazonaws.com/wt-write-api:$LATEST_TAG\",
     \"name\": \"wt-write-api\",
     \"memoryReservation\": 128,
     \"cpu\": 128

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "WT_CONFIG=test ./node_modules/.bin/nyc --reporter=text ./node_modules/mocha/bin/mocha --recursive --timeout 20000",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "start": "node src/index.js",
+    "docker-start": "npm run createdb && node src/index.js",
     "dev": "WT_CONFIG=dev node src/index.js",
     "createdb-dev": "WT_CONFIG=dev node management/createdb.js",
     "createdb": "node management/createdb.js",


### PR DESCRIPTION
This PR simplifies our AWS deployment by dropping the need to build the container twice (once for demo, once for playground). However, the containers are still pinned to sqlite, so it's not really that re-usable for a wider audience.